### PR TITLE
Suggest 128-byte alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### why it matters
 
-Modern processors retrieve data in memory into fast chip-local caches. At a practical level, the unit of memory retrieval is the cache line.  For most general purpose computing, the size of a cache line is 64 bytes (one cache line holds 64 UInt8s, 32 Int16s, 16 Float32s, or 8 Float64s). When data is stored aligned to this size, its retrieval is simpler. Straddling two cache lines with a single primitive bitstype value incurs costly delays.  
+Modern processors retrieve data in memory into fast chip-local caches. At a practical level, the unit of memory retrieval is the cache line.  For most general-purpose computing, the size of a cache line is 64 bytes (one cache line holds 64 UInt8s, 32 Int16s, 16 Float32s, or 8 Float64s), and you may want to align on double that size, so Julia's alignment is never optimal. When data is stored aligned to cache line size, its retrieval is simpler. Straddling two cache lines with a single primitive bitstype value incurs costly delays.  
 
 When using SIMD, alignment of 256 bytes (or more, depending on the processor) is critical to getting the throughput one expects from SIMD operations.  Running unaligned data through SIMD slows the processing down significantly.
 
@@ -28,7 +28,7 @@ element_type      = Float32   # a type T for which isbitstype(T) is true
 element_count     = 1024
 element_bytes     = sizeof(element_type) * element_count
 
-bytesofalignment  = 64 # bytes
+bytesofalignment  = 128 # bytes
 
 vec = memalign(element_type, element_count, bytesofalignment)
   


### PR DESCRIPTION
https://stackoverflow.com/questions/72126606/should-the-cache-padding-size-of-x86-64-be-128-bytes

Yes: https://github.com/facebook/folly/blob/1b5288e6eea6df074758f877c849b6e73bbb9fbb/folly/lang/Align.h#L107

Apple has 128-byte cache lines (unclear if fetches in pairs too, and then 256-byte alignment better?): https://cpufun.substack.com/p/more-m1-fun-hardware-information
  
https://lemire.me/blog/2023/12/12/measuring-the-size-of-the-cache-line-empirically/

Should you have a way to inspect what the cache-line size is and/or optimal alignment? Ideally this alignment should just be optimal in Julia, not needing a package, but I'm glad you've looked into this.

Possibly Julia or you should wrap:
>C++17 added std::hardware_destructive_interference_size and std::hardware_constructive_interference_size.

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0154r1.html

Some CPUs have 256-byte cache lines, but actually likely the one one example I found we do not need to worry about:
https://docs.rs/cache-padded/latest/cache_padded/  https://github.com/facebook/rocksdb/issues/4022

No x86-64 has 128-byte? Still recommended here for padding:
https://docs.rs/cache-padded/latest/cache_padded/

<!--
Thanks for making a pull request to AlignedAllocs.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide by the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [ ] I am following the [contributing guidelines](https://github.com/JeffreySarnoff/AlignedAllocs.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
- [ ] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
